### PR TITLE
Add OAuth support for Github applications

### DIFF
--- a/github/AccessToken.py
+++ b/github/AccessToken.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+
+############################ Copyrights and license ############################
+#                                                                              #
+# Copyright 2018 Rigas Papathanasopoulos <rigaspapas@gmail.com>                #
+#                                                                              #
+# This file is part of PyGithub.                                               #
+# http://pygithub.readthedocs.io/                                              #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+################################################################################
+
+import github.GithubObject
+
+
+class AccessToken(github.GithubObject.NonCompletableGithubObject):
+    """
+    This class represents access tokens.
+    """
+
+    def __repr__(self):
+        return self.get__repr__({
+            "token": "{}...".format(self.token[:5]),
+            "scope": self.scope,
+            "type": self.type,
+        })
+
+    @property
+    def token(self):
+        """
+        :type: string
+        """
+        return self._token.value
+
+    @property
+    def type(self):
+        """
+        :type: string
+        """
+        return self._type.value
+
+    @property
+    def scope(self):
+        """
+        :type: string
+        """
+        return self._scope.value
+
+    def _initAttributes(self):
+        self._token = github.GithubObject.NotSet
+        self._type = github.GithubObject.NotSet
+        self._scope = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "access_token" in attributes:  # pragma no branch
+            self._token = self._makeStringAttribute(attributes["access_token"])
+        if "token_type" in attributes:  # pragma no branch
+            self._type = self._makeStringAttribute(attributes["token_type"])
+        if "scope" in attributes:  # pragma no branch
+            self._scope = self._makeStringAttribute(attributes["scope"])

--- a/github/ApplicationAuthorization.py
+++ b/github/ApplicationAuthorization.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+
+############################ Copyrights and license ###########################
+#                                                                             #
+# Copyright 2018 Rigas Papathanasopoulos <rigaspapas@gmail.com>               #
+#                                                                             #
+# This file is part of PyGithub.                                              #
+# http://pygithub.readthedocs.io/                                             #
+#                                                                             #
+# PyGithub is free software: you can redistribute it and/or modify it under   #
+# the terms of the GNU Lesser General Public License as published by the Free #
+# Software Foundation, either version 3 of the License, or (at your option)   #
+# any later version.                                                          #
+#                                                                             #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS   #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more#
+# details.                                                                    #
+#                                                                             #
+# You should have received a copy of the GNU Lesser General Public License    #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.            #
+#                                                                             #
+###############################################################################
+
+import json
+import urllib
+from httplib import HTTPSConnection
+
+import github.GithubObject
+from github.AccessToken import AccessToken
+from github.GithubException import GithubException
+from github.MainClass import atLeastPython3
+
+
+class ApplicationAuthorization(github.GithubObject.CompletableGithubObject):
+    """
+    This class is used for identifying and authorizing users for Github Apps.
+    https://developer.github.com/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#1-users-are-redirected-to-request-their-github-identity
+    """
+
+    def __init__(self, client_id, client_secret, redirect_uri=None, state=None,
+                 login=None):
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.redirect_uri = redirect_uri
+        self.state = state
+        self.login = login
+
+    @property
+    def login_url(self):
+        """
+        Return the URL you need to redirect a user to in order to authorize
+        your App.
+        :type: string
+        """
+        params = {}
+        possible_params = ['client_id', 'redirect_uri', 'state', 'login']
+        for param in possible_params:
+            value = getattr(self, param)
+            if value is not None:
+                params[param] = value
+
+        if atLeastPython3:
+            params = urllib.parse.urlencode(params)
+        else:
+            params = urllib.urlencode(params)
+
+        base_url = 'https://github.com/login/oauth/authorize'
+        return '{}?{}'.format(base_url, params)
+
+    def get_access_token(self, code, state=None):
+        """
+        :calls: `POST /login/oauth/access_token <https://developer.github.com/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/>`_
+        :param code: string
+        """
+        assert isinstance(code, (str, unicode)), code
+        params = {
+            "code": code,
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+        }
+
+        if state is not None:
+            params["state"] = state
+
+        conn = HTTPSConnection("github.com")
+        conn.request(
+            method="POST",
+            url="/login/oauth/access_token",
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+                "User-Agent": "PyGithub/Python",
+            },
+            body=json.dumps(params),
+        )
+        response = conn.getresponse()
+        response_text = response.read()
+
+        if atLeastPython3:
+            response_text = response_text.decode("utf-8")
+
+        conn.close()
+        if response.status >= 200 and response.status < 300:
+            data = json.loads(response_text)
+            return AccessToken(
+                # not required, this is a NonCompletableGithubObject
+                requester=None,
+                # not required, this is a NonCompletableGithubObject
+                headers={},
+                attributes=data,
+                completed=True
+            )
+        raise GithubException(
+            status=response.status,
+            data=response_text
+        )

--- a/github/AuthenticatedUser.py
+++ b/github/AuthenticatedUser.py
@@ -54,6 +54,7 @@ import github.Issue
 import github.Event
 import github.Authorization
 import github.Notification
+from github.Installation import INTEGRATION_PREVIEW_HEADERS
 
 
 class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
@@ -974,6 +975,20 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
             self._requester,
             "/user/subscriptions",
             None
+        )
+
+    def get_installations(self):
+        """
+        :calls: `GET /user/installations <http://developer.github.com/v3/apps>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Repository.Repository`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Installation.Installation,
+            self._requester,
+            "/user/installations",
+            None,
+            headers=INTEGRATION_PREVIEW_HEADERS,
+            list_item="installations",
         )
 
     def has_in_following(self, following):


### PR DESCRIPTION
* Create the ApplicationAuthorization class which is responsible for handling a Github application's user authorization via OAuth.

* Create an AccessToken class to represent access tokens acquired via OAuth.

* Implement the endpoint that gets a user's installations.